### PR TITLE
fix: article edit link

### DIFF
--- a/app/routes/articles_.$category.$article-title.tsx
+++ b/app/routes/articles_.$category.$article-title.tsx
@@ -55,7 +55,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
 
 export default function ArticlePage() {
   const {
-    article:{ category, title, content, lastUpdatedAt, readingTime },
+    article:{ category, title, content, lastUpdatedAt, readingTime, permalink },
     recentArticles,
   } = useLoaderData<typeof loader>();
 
@@ -66,7 +66,7 @@ export default function ArticlePage() {
         <a
           className={styles.editButton}
           title='edit'
-          href={BlogConfig.content.source + category + '/' + title + '.md'}
+          href={BlogConfig.content.source + category + '/' + (permalink ?? title) + '.md'}
           target='_blank'
           rel='noopener noreferrer'
         >


### PR DESCRIPTION
### Changes

- Modify the edit link to use `permalink` if it exists, otherwise fall back to the original `title`.

### Reason for Changes

- If `permalink` exists, it will be used to generate a more accurate edit link.
- References:
  - [Code 1](https://github.com/jbee37142/jbee.io/blob/6bac19cccd8fc4b56a2a69f8716e06029e73c77c/app/modules/article/articles-section.tsx#L22)
  - [Code 2](https://github.com/jbee37142/jbee.io/blob/6bac19cccd8fc4b56a2a69f8716e06029e73c77c/app/routes/articles.tsx#L33)

### Testing

- [x] Verify that the edit link is correctly updated when `permalink` is provided.
- [x] Verify that the `title` is used when `permalink` is not available.

---

*Translated with AI*
